### PR TITLE
Fix error when disabling status line

### DIFF
--- a/scripts/status-line.lua
+++ b/scripts/status-line.lua
@@ -83,7 +83,7 @@ function disable()
     mp.unobserve_property(mark_stale)
     mp.unregister_idle(refresh)
     ass.status_line = ""
-    draw_ass()
+    draw_ass("")
 end
 
 function toggle()


### PR DESCRIPTION
For me, running `disable-status-line` fails, giving this error:

```
[status_line] Command osd-overlay: required argument data not set.
```

This is because `mp.set_osd_ass`'s third argument is required. Simply calling `draw_ass` with an empty string as its argument is enough to fix this.